### PR TITLE
feat: CP-SAT status reporting + packaging/mypy fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,44 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `cashflow/`: Python package.
-  - `core/`: models, ledger, validation.
-  - `engines/`: solvers (`dp.py`, `cpsat.py`).
-  - `io/`: plan loading and markdown rendering.
-  - `cli.py`: Typer CLI entry point.
-- `cashflow/tests/`: `unit/`, `property/`, `regression/` suites.
-- Root: `plan.json` (example input), `Makefile`, `pyproject.toml`, `requirements.txt`.
+- `cashflow/`: Python package
+  - `core/`: money utils, models, ledger, validation
+  - `engines/`: solvers (`dp.py`, `cpsat.py`)
+  - `io/`: plan loading and renderers (md/csv/json)
+  - `cli.py`: Typer CLI entrypoint
+- `cashflow/tests/`: `unit/`, `property/`, `regression/`
+- `api/`: FastAPI serverless endpoints (`/solve`, `/set_eod`, `/export`)
+- `verify_service/`: containerized CP‑SAT verify API
+- `web/`: Next.js UI (optional for local dev)
+- Root: `plan.json`, `Makefile`, `pyproject.toml`, `requirements.txt`
 
 ## Build, Test, and Development Commands
-- `make setup`: install dependencies from `requirements.txt` (Python 3.11+).
-- `make test`: run the full `pytest` suite.
-- `make lint`: static checks with `ruff` and `black --check`.
-- `make format`: auto-format with `black` and fix lints.
-- `make type`: type checks with `mypy`.
-- `make verify`: cross-check DP vs CP-SAT objective.
-- Run CLI locally:
-  - `python -m cashflow.cli show|solve|export|verify`
-  - After editable install: `pip install -e .` then `cash solve`.
+- `make setup` — install dependencies (Python 3.11+)
+- `make test` — run the full pytest suite
+- `make lint` — `ruff` + `black --check`
+- `make format` — auto-format + fix lints
+- `make type` — mypy type checks
+- `make verify` — CP‑SAT cross‑check of DP objective
+- CLI: `python -m cashflow.cli show|solve|export|verify`
+  - After editable install (`pip install -e .`): `cash solve`
 
 ## Coding Style & Naming Conventions
-- Use Black formatting (4-space indent). Keep lines per Black defaults.
-- Type hints required for public functions; run `make type` before PRs.
-- Naming: modules/functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE_CASE`.
-- Lint with `ruff`; keep imports ordered; avoid unused code and broad exceptions.
+- Black formatting (4‑space indent); imports ordered; no unused/broad excepts
+- Public functions typed; run `make type` before PRs
+- Names: modules/functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE_CASE`
 
 ## Testing Guidelines
-- Frameworks: `pytest` + `hypothesis` for property-based checks.
-- Location: `cashflow/tests/{unit,property,regression}/`; files `test_*.py`, functions `test_*`.
-- Common commands:
-  - `pytest -q`
-  - `pytest -q cashflow/tests/unit -k cli`
-- No strict coverage gate; add unit tests with behavior changes and property tests when applicable.
+- Frameworks: `pytest` + `hypothesis` (property tests)
+- Location: `cashflow/tests/{unit,property,regression}`; files `test_*.py`
+- Quick runs: `pytest -q`, or `pytest -q cashflow/tests/unit -k cli`
+- Add tests with behavior changes; property tests when applicable (no strict coverage gate)
 
 ## Commit & Pull Request Guidelines
-- Prefer Conventional Commits (e.g., `feat: add dp tie-break`, `fix: guard negative balance`).
-- PRs should include: clear description, linked issue, rationale, sample CLI output (e.g., `python -m cashflow.cli verify`), and tests.
-- Keep changes focused; update docs when user-facing behavior changes.
+- Conventional Commits (e.g., `feat: add dp tie-break`, `fix: guard negative balance`)
+- PRs include: description, linked issue, rationale, sample CLI output (e.g., `python -m cashflow.cli verify`), and tests
+- Keep changes focused; update docs when user‑facing behavior changes
 
 ## Architecture Overview
-- DP engine (`engines/dp.py`) produces feasible 30-day schedules over integer cents.
-- Validator (`core/validate.py`) enforces constraints; CP-SAT (`engines/cpsat.py`) verifies lexicographic optimality.
-- Input is `plan.json` at repo root; renderers output markdown tables for human review.
-
+- DP (`engines/dp.py`) computes feasible 30‑day schedules over integer cents
+- Validator enforces non‑negativity, Day‑1 `L`, rolling `O,O` window, end‑band, and Day‑30 pre‑rent guard
+- CP‑SAT (`engines/cpsat.py`) verifies lexicographic optimality and can enumerate ties

--- a/cashflow/cli.py
+++ b/cashflow/cli.py
@@ -70,6 +70,12 @@ def cmd_verify(
     report = verify_lex_optimal(plan, schedule)
     typer.echo("DP Objective:   " + str(schedule.objective))
     typer.echo("CP-SAT Objective: " + str(report.cp_obj))
+    if getattr(report, "statuses", None):
+        names = ["workdays", "b2b", "|Δ|", "large_days", "single_pen"]
+        typer.echo("Solver statuses:")
+        for i, s in enumerate(report.statuses):
+            label = names[i] if i < len(names) else f"part{i+1}"
+            typer.echo(f"- {label}: {s}")
     if report.ok:
         if report.dp_obj == report.cp_obj and report.dp_actions != report.cp_actions:
             typer.echo("Objectives match; actions differ (tie)")

--- a/cashflow/cli.py
+++ b/cashflow/cli.py
@@ -73,7 +73,7 @@ def cmd_verify(
     if getattr(report, "statuses", None):
         names = ["workdays", "b2b", "|Δ|", "large_days", "single_pen"]
         typer.echo("Solver statuses:")
-        for i, s in enumerate(report.statuses):
+        for i, s in enumerate(report.statuses or []):
             label = names[i] if i < len(names) else f"part{i+1}"
             typer.echo(f"- {label}: {s}")
     if report.ok:

--- a/cashflow/engines/cpsat.py
+++ b/cashflow/engines/cpsat.py
@@ -188,7 +188,7 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
     return sols
 
 
-def _status_name(code: int) -> str:
+def _status_name(code: object) -> str:
     try:
         if code == cp_model.OPTIMAL:
             return "OPTIMAL"

--- a/cashflow/engines/cpsat.py
+++ b/cashflow/engines/cpsat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 try:
     from ortools.sat.python import cp_model
@@ -37,7 +37,7 @@ class VerificationReport:
     dp_actions: List[str]
     cp_actions: List[str]
     detail: str = ""
-    statuses: List[str] = None  # type: ignore[assignment]
+    statuses: Optional[List[str]] = None
 
 
 def _build_model(plan: Plan):

--- a/cashflow/tests/unit/test_cli.py
+++ b/cashflow/tests/unit/test_cli.py
@@ -21,3 +21,15 @@ def test_cli_export_writes_file(tmp_path):
     assert out_path.exists()
     text = out_path.read_text()
     assert "Objective:" in text
+
+
+def test_cli_verify_prints_statuses():
+    result = runner.invoke(app, ["verify"])
+    assert result.exit_code == 0
+    out = result.stdout
+    # Core lines
+    assert "DP Objective:" in out
+    assert "CP-SAT Objective:" in out
+    # New status section
+    assert "Solver statuses:" in out
+    assert "- workdays:" in out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
 [project.scripts]
 cash = "cashflow.cli:main"
 
+[tool.setuptools.packages.find]
+include = ["cashflow*"]
+exclude = ["api*", "web*", "ui*", "verify_service*"]


### PR DESCRIPTION
- Add per-stage CP-SAT status reporting and surface via CLI verify\n- Add CLI unit test asserting status output\n- Restrict setuptools package discovery to cashflow only (fix editable install in CI)\n- Typing fixes for VerificationReport.statuses and _status_name to satisfy mypy\n\nCI is green on branch. Merging into main.]