### PR TITLE
feat: migrate schedule to spark workdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Highlights
 
 - Integer‑cents math for correctness and determinism
-- Hard constraints: non‑negative daily closings, Day‑1 Large, 7‑day Off‑Off window, Day‑30 pre‑rent guard, final balance band
-- Lexicographic objective: `(workdays, b2b, |final−target|, large_days, single_pen)`
+- Hard constraints: non‑negative daily closings, Day‑1 Spark, 7‑day Off‑Off window, Day‑30 pre‑rent guard, final balance band
+- Lexicographic objective: `(workdays, b2b, |final−target|)`
 - Fast “resume from any day” via manual adjustment (API) or `solve_from()` helper (library)
 - Optional CP‑SAT verification and tie enumeration
 
@@ -24,14 +24,15 @@ How It Works
 - Model and money
   - All amounts are integer cents; `to_cents()`/`cents_to_str()` in `cashflow/core/model.py`.
   - `Plan` holds inputs; `DayLedger`/`Schedule` capture the solved plan.
+  - `SHIFT_NET_CENTS = {"O": 0, "Spark": 10_000}` encodes the Spark workday payout ($100 net).
 - Ledger and validation
   - `build_ledger(plan, actions)` constructs daily rows (opening → deposits → action net → bills → closing).
-  - `validate(plan, schedule)` checks: Day‑1 Large, non‑negativity, final band, Day‑30 pre‑rent guard, and Off‑Off in every 7‑day window.
+  - `validate(plan, schedule)` checks: Day‑1 Spark, non‑negativity, final band, Day‑30 pre‑rent guard, and Off‑Off in every 7‑day window.
 - DP solver (`cashflow/engines/dp.py`)
-  - State: `(last6_off_bits, prevWorked, workUsed, net)` and additive costs `(b2b, large_days, single_pen)`.
-  - Feasibility: rolling Off‑Off, non‑negativity, Day‑30 pre‑rent guard, optional locks, Day‑1 Large.
-  - Selection: choose final states within the band minimizing `(workUsed, b2b, |Δ|, large_days, single_pen)`.
-  - Helpers: `solve_from(plan, start_day)` re‑solves tail days by locking a prefix; internal flag `forbid_large_after_day1` exists but is not exposed via CLI.
+  - State: `(last6_off_bits, prevWorked, workUsed, net)` and additive costs `(b2b)`.
+  - Feasibility: rolling Off‑Off, non‑negativity, Day‑30 pre‑rent guard, optional locks, Day‑1 Spark.
+  - Selection: choose final states within the band minimizing `(workUsed, b2b, |Δ|)`.
+  - Helpers: `solve_from(plan, start_day)` re‑solves tail days by locking a prefix; internal flag `forbid_large_after_day1` (legacy name) disables Spark after Day 1 but is not exposed via CLI.
 - CP‑SAT verifier (`cashflow/engines/cpsat.py`)
   - Builds an equivalent model with one‑hot daily actions and sequential lexicographic minimization.
   - `verify_lex_optimal(plan, dp_schedule)` compares DP vs CP‑SAT objectives; CLI shows per‑stage solver statuses.

--- a/cashflow/cli.py
+++ b/cashflow/cli.py
@@ -112,7 +112,7 @@ def cmd_verify(
     typer.echo("DP Objective:   " + str(schedule.objective))
     typer.echo("CP-SAT Objective: " + str(report.cp_obj))
     if getattr(report, "statuses", None):
-        names = ["workdays", "b2b", "|Δ|", "large_days", "single_pen"]
+        names = ["workdays", "b2b", "|Δ|"]
         typer.echo("Solver statuses:")
         for i, s in enumerate(report.statuses or []):
             label = names[i] if i < len(names) else f"part{i+1}"

--- a/cashflow/core/model.py
+++ b/cashflow/core/model.py
@@ -17,13 +17,10 @@ def cents_to_str(cents: int) -> str:
     return f"{sign}{cents_abs // 100}.{cents_abs % 100:02d}"
 
 
-# Shift net values (already subtracting $8 work cost when worked)
+# Shift net values (Spark workdays pay $100; no per-day deductions applied)
 SHIFT_NET_CENTS: Dict[str, int] = {
     "O": 0,
-    "S": 5600,
-    "M": 6750,
-    "L": 8650,
-    "SS": 12000,
+    "Spark": 10_000,
 }
 
 
@@ -74,8 +71,8 @@ class DayLedger:
 
 @dataclass
 class Schedule:
-    actions: List[str]  # 30 entries from {O,S,M,L,SS}
-    objective: Tuple[int, int, int, int, int]
+    actions: List[str]  # 30 entries from {O, Spark}
+    objective: Tuple[int, int, int]
     final_closing_cents: int
     ledger: List[DayLedger]
 

--- a/cashflow/core/validate.py
+++ b/cashflow/core/validate.py
@@ -29,9 +29,9 @@ def validate(plan: Plan, schedule: Schedule) -> ValidationReport:
     dep, bills, base = build_prefix_arrays(plan)
     checks: List[Tuple[str, bool, str]] = []
 
-    # Day 1 must be L
-    day1_ok = schedule.actions[0] == "L"
-    checks.append(("Day 1 Large", day1_ok, schedule.actions[0]))
+    # Day 1 must be a Spark workday
+    day1_ok = schedule.actions[0] == "Spark"
+    checks.append(("Day 1 Spark", day1_ok, schedule.actions[0]))
 
     # Non-negativity & bills paid by construction
     nonneg_ok = True

--- a/cashflow/engines/cpsat.py
+++ b/cashflow/engines/cpsat.py
@@ -6,20 +6,19 @@ captures the same feasibility rules and objective used by the DP solver. It is
 used to:
 
 - Solve a sequential lexicographic objective (workdays, back-to-back work,
-  |final diff|, number of large days, and a final single-day penalty) and
-  extract an optimal 30-day schedule.
+  and |final diff|) and extract an optimal 30-day schedule.
 - Cross-check a DP-produced schedule for lexicographic optimality.
 - Enumerate alternative schedules ("ties") that achieve the exact same
   lexicographic objective value.
 
 Key ideas:
-- One-hot action variable per day over ACTIONS = ("O","S","M","L","SS").
+- One-hot action variable per day over ACTIONS = ("O","Spark").
 - Derived boolean indicators for off/work, back-to-back work pairs, and
   off-off pairs in adjacent days.
 - Integer prefix balance recursion over net cents deltas per action.
 - Feasibility constraints mirror validator rules: non-negative daily closings,
-  Day-1 Large, Day-30 pre-rent guard, final band, and an Off-Off window rule.
-- Sequential lexicographic optimization modeled by solving 5 stages in order
+  Day-1 Spark, Day-30 pre-rent guard, final band, and an Off-Off window rule.
+- Sequential lexicographic optimization modeled by solving 3 stages in order
   and fixing the previous objective part to its optimum before proceeding.
 """
 
@@ -57,11 +56,12 @@ from ..core.model import (
 #   applying action deltas on or before Day-30).
 
 
-ActionList = ["O", "S", "M", "L", "SS"]
+ActionList = ["O", "Spark"]
 # Canonical action order used to index decision variables. This order must
 # match how SHIFT_NET_CENTS is accessed below.
-ACTIONS = ("O", "S", "M", "L", "SS")
+ACTIONS = ("O", "Spark")
 IDX: Dict[str, int] = {a: i for i, a in enumerate(ACTIONS)}
+NUM_ACTIONS = len(ACTIONS)
 
 
 @dataclass
@@ -69,13 +69,13 @@ class CPSATSolution:
     """Container for a CP-SAT schedule and its objective components.
 
     - actions: the chosen action symbol per day (length 30)
-    - objective: 5-tuple in lexicographic order
+    - objective: 3-tuple in lexicographic order
     - final_closing_cents: closing balance on Day-30
     - statuses: per-stage CP-SAT status names during lex solve
     """
 
     actions: List[str]
-    objective: Tuple[int, int, int, int, int]
+    objective: Tuple[int, int, int]
     final_closing_cents: int
     statuses: List[str]
 
@@ -90,8 +90,8 @@ class VerificationReport:
     """
 
     ok: bool
-    dp_obj: Tuple[int, int, int, int, int]
-    cp_obj: Tuple[int, int, int, int, int]
+    dp_obj: Tuple[int, int, int]
+    cp_obj: Tuple[int, int, int]
     dp_actions: List[str]
     cp_actions: List[str]
     detail: str = ""
@@ -126,7 +126,7 @@ def _build_model(plan: Plan):
 
     # Decision vars
     # x[t][a] == 1 iff action `ACTIONS[a]` is chosen on day t.
-    x = [[model.NewBoolVar(f"x_{t}_{a}") for a in range(5)] for t in range(30)]
+    x = [[model.NewBoolVar(f"x_{t}_{a}") for a in range(NUM_ACTIONS)] for t in range(30)]
     off = [model.NewBoolVar(f"off_{t}") for t in range(30)]
     w = [model.NewBoolVar(f"w_{t}") for t in range(30)]
     # Adjacent-pair indicators for (work,work) and (off,off).
@@ -134,14 +134,18 @@ def _build_model(plan: Plan):
     oo = [model.NewBoolVar(f"oo_{t}") for t in range(29)]
     # Cumulative sum of action deltas (in cents) up to day t.
     # Upper bound is a safe coarse cap to keep domains finite.
-    prefix_net = [model.NewIntVar(0, 12000 * (t + 1), f"pref_{t}") for t in range(30)]
+    max_day_net = max(SHIFT_NET_CENTS.values())
+    prefix_net = [
+        model.NewIntVar(0, max_day_net * (t + 1), f"pref_{t}") for t in range(30)
+    ]
     final_close = model.NewIntVar(-(10**9), 10**9, "final_close")
     abs_diff = model.NewIntVar(0, 10**9, "abs_diff")
 
     # Rationale for domains:
-    # - prefix_net: coarse upper bounds (12k per day) are conservative but
-    #   avoid needless search by preventing unbounded growth; lower bound 0 is
-    #   consistent with non-negative or zero net deltas in SHIFT_NET_CENTS.
+    # - prefix_net: coarse upper bounds (max Spark payout per day) are
+    #   conservative but avoid needless search by preventing unbounded growth;
+    #   lower bound 0 is consistent with non-negative or zero net deltas in
+    #   SHIFT_NET_CENTS.
     # - final_close: wide bounds; we subsequently constrain it to the target
     #   band, which effectively tightens its domain during solving.
     # - abs_diff: non-negative absolute deviation, linked via AddAbsEquality.
@@ -154,13 +158,13 @@ def _build_model(plan: Plan):
         # This is how users can "pin" certain days when exploring schedules.
         locked = plan.actions[t]
         if locked is not None:
-            for a in range(5):
+            for a in range(NUM_ACTIONS):
                 model.Add(x[t][a] == (1 if a == IDX[locked] else 0))
 
-    # Day 1 Large
-    # Business rule: the first day must be a Large shift. This mirrors the
+    # Day 1 Spark
+    # Business rule: the first day must be a Spark shift. This mirrors the
     # validator and DP solver’s model assumptions.
-    model.Add(x[0][IDX["L"]] == 1)
+    model.Add(x[0][IDX["Spark"]] == 1)
 
     # off, w
     for t in range(30):
@@ -187,12 +191,13 @@ def _build_model(plan: Plan):
     # Map actions to per-day net cents deltas.
     net_vec = [SHIFT_NET_CENTS[a] for a in ACTIONS]
     # day 0
-    model.Add(prefix_net[0] == sum(net_vec[a] * x[0][a] for a in range(5)))
+    model.Add(prefix_net[0] == sum(net_vec[a] * x[0][a] for a in range(NUM_ACTIONS)))
     for t in range(1, 30):
         # prefix_net[t] = prefix_net[t-1] + net(action_t)
         model.Add(
             prefix_net[t]
-            == prefix_net[t - 1] + sum(net_vec[a] * x[t][a] for a in range(5))
+            == prefix_net[t - 1]
+            + sum(net_vec[a] * x[t][a] for a in range(NUM_ACTIONS))
         )
     # With base[] provided by build_prefix_arrays, the closing balance on day t
     # is base[t+1] + prefix_net[t]. The constraints below enforce feasibility.
@@ -220,24 +225,18 @@ def _build_model(plan: Plan):
         model.Add(sum(oo[i] for i in range(s, s + 6)) >= 1)
 
     # Objective components
-    # We optimize lexicographically over these five parts (in order):
+    # We optimize lexicographically over these three parts (in order):
     # 1) Minimize total workdays; 2) minimize back-to-back work pairs;
-    # 3) minimize |final diff from target|; 4) minimize number of Large days;
-    # 5) minimize a tie-breaker penalizing M and especially L.
+    # 3) minimize |final diff from target|.
     workdays = sum(w)
     b2b_sum = sum(b2b)
-    large_days = sum(x[t][IDX["L"]] for t in range(30))
-    single_pen = sum(x[t][IDX["M"]] + 2 * x[t][IDX["L"]] for t in range(30))
     # Notes:
     # - workdays: encourages more off days when feasible.
     # - b2b_sum: discourages consecutive working days to spread work out.
     # - abs_diff: centers final balance within the target band with a preference
     #   toward the target itself when multiple values lie within the band.
-    # - large_days: prefers fewer Large shifts after satisfying (1)-(3).
-    # - single_pen: final tie-breaker to prefer Medium over Large, and avoid
-    #   unnecessary Mediums as well.
 
-    return model, x, (workdays, b2b_sum, abs_diff, large_days, single_pen), final_close
+    return model, x, (workdays, b2b_sum, abs_diff), final_close
 
 
 def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
@@ -258,16 +257,14 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
     # First, get the optimal objective via sequential lex optimization
     model_opt, x_opt, obj_parts, final_close_opt = _build_model(plan)
     solver_opt = cp_model.CpSolver()
-    w, b2b, absd, large, sp = _solve_sequential_lex(model_opt, obj_parts, solver_opt)
+    w, b2b, absd = _solve_sequential_lex(model_opt, obj_parts, solver_opt)
 
     # Build a fresh model with the same constraints and fix the objective parts to the optimal values
     model, x, obj_parts2, final_close = _build_model(plan)
-    workdays, b2b_sum, abs_diff, large_days, single_pen = obj_parts2
+    workdays, b2b_sum, abs_diff = obj_parts2
     model.Add(workdays == w)
     model.Add(b2b_sum == b2b)
     model.Add(abs_diff == absd)
-    model.Add(large_days == large)
-    model.Add(single_pen == sp)
 
     # Enumerate feasible solutions (no objective)
     sols: List[CPSATSolution] = []
@@ -284,7 +281,7 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
             actions: List[str] = []
             for t in range(30):
                 idx = None
-                for a in range(5):
+                for a in range(NUM_ACTIONS):
                     if self.Value(x[t][a]) == 1:
                         idx = a
                         break
@@ -298,7 +295,7 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
             sols.append(
                 CPSATSolution(
                     actions=actions,
-                    objective=(w, b2b, absd, large, sp),
+                    objective=(w, b2b, absd),
                     final_closing_cents=final_cents,
                 )
             )
@@ -335,14 +332,14 @@ def _status_name(code: object) -> str:
 
 
 def _solve_sequential_lex(model, obj_parts, solver: "cp_model.CpSolver"):
-    """Solve a 5-part lexicographic objective sequentially.
+    """Solve a 3-part lexicographic objective sequentially.
 
     At each stage, minimize the current part, record the optimum, then add an
     equality constraint fixing that part before moving to the next. This is a
     standard technique to emulate lexicographic optimization with CP-SAT.
     Returns the optimal values for each part along with per-stage statuses.
     """
-    workdays, b2b_sum, abs_diff, large_days, single_pen = obj_parts
+    workdays, b2b_sum, abs_diff = obj_parts
 
     statuses: List[str] = []
 
@@ -375,23 +372,7 @@ def _solve_sequential_lex(model, obj_parts, solver: "cp_model.CpSolver"):
     best_abs = solver.Value(abs_diff)
     model.Add(abs_diff == best_abs)
 
-    # 4) Minimize large_days
-    model.Minimize(large_days)
-    r = solver.Solve(model)
-    statuses.append(_status_name(r))
-    if r not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        raise RuntimeError("CP-SAT failed for objective 4")
-    best_large = solver.Value(large_days)
-    model.Add(large_days == best_large)
-
-    # 5) Minimize single_pen (final tie-breaker among Large/Medium usage)
-    model.Minimize(single_pen)
-    r = solver.Solve(model)
-    statuses.append(_status_name(r))
-    if r not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        raise RuntimeError("CP-SAT failed for objective 5")
-
-    return best_work, best_b2b, best_abs, best_large, solver.Value(single_pen), statuses
+    return best_work, best_b2b, best_abs, statuses
 
 
 def solve_lex(plan: Plan) -> CPSATSolution:
@@ -401,13 +382,13 @@ def solve_lex(plan: Plan) -> CPSATSolution:
 
     model, x, obj_parts, final_close = _build_model(plan)
     solver = cp_model.CpSolver()
-    w, b2b, absd, large, sp, statuses = _solve_sequential_lex(model, obj_parts, solver)
+    w, b2b, absd, statuses = _solve_sequential_lex(model, obj_parts, solver)
 
     # Extract actions from the solved one-hot variables.
     actions: List[str] = []
     for t in range(30):
         idx = None
-        for a in range(5):
+        for a in range(NUM_ACTIONS):
             if solver.Value(x[t][a]) == 1:
                 idx = a
                 break
@@ -419,7 +400,7 @@ def solve_lex(plan: Plan) -> CPSATSolution:
     final_cents = solver.Value(final_close)
     sol = CPSATSolution(
         actions=actions,
-        objective=(w, b2b, absd, large, sp),
+        objective=(w, b2b, absd),
         final_closing_cents=final_cents,
         statuses=statuses,
     )
@@ -438,7 +419,7 @@ def verify_lex_optimal(plan: Plan, schedule_dp) -> VerificationReport:
         return VerificationReport(
             ok=False,
             dp_obj=schedule_dp.objective,
-            cp_obj=(-1, -1, -1, -1, -1),
+            cp_obj=(-1, -1, -1),
             dp_actions=schedule_dp.actions,
             cp_actions=[],
             detail=f"CP-SAT error: {e}",

--- a/cashflow/engines/dp.py
+++ b/cashflow/engines/dp.py
@@ -14,15 +14,13 @@ from ..core.model import (
 from ..core.ledger import build_ledger
 
 
-Action = str  # 'O','S','M','L','SS'
+Action = str  # 'O' or 'Spark'
 
 
 @dataclass
 class _StateVal:
     # costs that are additive across days
     b2b: int
-    large_days: int
-    single_pen: int
     back: Optional[Tuple]  # (prev_state_key, action)
 
 
@@ -32,10 +30,10 @@ def _allowed_actions(
     if locked is not None:
         return [locked]
     if day == 1:
-        return ["L"]
+        return ["Spark"]
     if forbid_large_after_day1:
-        return ["O", "S", "M", "SS"]
-    return ["O", "S", "M", "SS", "L"]
+        return ["O"]
+    return ["O", "Spark"]
 
 
 def _has_off_off(vec: List[int]) -> bool:
@@ -53,7 +51,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
     min_net = (plan.target_end_cents - plan.band_cents) - base_end
     max_net = (plan.target_end_cents + plan.band_cents) - base_end
     # Max per remaining day
-    MAX_DAY_NET = 12000
+    MAX_DAY_NET = max(SHIFT_NET_CENTS.values())
 
     pre30 = pre_rent_base_on_day30(plan, dep, bills)
 
@@ -61,9 +59,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
     # State key: (last6_off_tuple, prevWorked:int, workUsed:int, net:int)
     # last6_off_tuple: tuple[int,...] oldest->newest, len<=6
     layers: List[Dict[Tuple, _StateVal]] = []
-    s0: Dict[Tuple, _StateVal] = {
-        ((), 0, 0, 0): _StateVal(b2b=0, large_days=0, single_pen=0, back=None)
-    }
+    s0: Dict[Tuple, _StateVal] = {((), 0, 0, 0): _StateVal(b2b=0, back=None)}
     layers.append(s0)
 
     for day in range(1, 31):
@@ -108,36 +104,22 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
 
                 # Update costs
                 b2b_new = val.b2b + (1 if (prevW == 1 and will_work == 1) else 0)
-                large_days_new = val.large_days + (1 if a == "L" else 0)
-                single_pen_new = val.single_pen + (
-                    1 if a == "M" else 2 if a == "L" else 0
-                )
 
                 state_key = (last6_new, 1 if will_work else 0, work_used_new, net_new)
                 new_val = _StateVal(
                     b2b=b2b_new,
-                    large_days=large_days_new,
-                    single_pen=single_pen_new,
                     back=((last6_off_tuple, prevW, workUsed, net), a),
                 )
 
-                # Keep lexicographically best by (work_used, b2b, large_days, single_pen)
+                # Keep lexicographically best by (work_used, b2b)
                 existing = cur.get(state_key)
-                if existing is None:
+                if existing is None or b2b_new < existing.b2b:
                     cur[state_key] = new_val
-                else:
-                    if (work_used_new, b2b_new, large_days_new, single_pen_new) < (
-                        work_used_new,
-                        existing.b2b,
-                        existing.large_days,
-                        existing.single_pen,
-                    ):
-                        cur[state_key] = new_val
 
         layers.append(cur)
 
     # Select best final state within band
-    best_tuple: Optional[Tuple[Tuple[int, int, int, int, int], Tuple, _StateVal]] = None
+    best_tuple: Optional[Tuple[Tuple[int, int, int], Tuple, _StateVal]] = None
     for (last6_off, prevW, workUsed, net), val in layers[-1].items():
         final_closing = base[30] + net
         if not (
@@ -147,7 +129,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
         ):
             continue
         abs_delta = abs(final_closing - plan.target_end_cents)
-        obj = (workUsed, val.b2b, abs_delta, val.large_days, val.single_pen)
+        obj = (workUsed, val.b2b, abs_delta)
         if best_tuple is None or obj < best_tuple[0]:
             best_tuple = (obj, (last6_off, prevW, workUsed, net), val)
 

--- a/cashflow/io/render.py
+++ b/cashflow/io/render.py
@@ -8,8 +8,8 @@ from ..core.model import Schedule, cents_to_str
 def render_markdown(schedule: Schedule) -> str:
     lines: List[str] = []
     # Display shift payout as its own column and list it after the action
-    # to reflect that Flex deposits occur after working (SS deposits after
-    # the second shift). External deposits remain in the Deposits column.
+    # to reflect that Spark deposits occur after working. External deposits
+    # remain in the Deposits column.
     lines.append("| Day | Opening | Action | Payout | Deposits | Bills | Closing |")
     lines.append("| ---:| -------:|:------:| ------:| --------:| -----:| -------:|")
     for row in schedule.ledger:
@@ -17,9 +17,9 @@ def render_markdown(schedule: Schedule) -> str:
             f"| {row.day:>3} | {cents_to_str(row.opening_cents):>7} | {row.action:^6} | {cents_to_str(row.net_cents):>6} | {cents_to_str(row.deposit_cents):>8} | {cents_to_str(row.bills_cents):>5} | {cents_to_str(row.closing_cents):>7} |"
         )
     lines.append("")
-    w, b2b, delta, large, sp = schedule.objective
+    w, b2b, delta = schedule.objective
     lines.append(
-        f"Objective: workdays={w}, b2b={b2b}, |Δ|={cents_to_str(delta)}, large_days={large}, single_pen={sp}"
+        f"Objective: workdays={w}, b2b={b2b}, |Δ|={cents_to_str(delta)}"
     )
     lines.append(f"Final closing: {cents_to_str(schedule.final_closing_cents)}")
     return "\n".join(lines)

--- a/cashflow/tests/property/test_randomized_target_band.py
+++ b/cashflow/tests/property/test_randomized_target_band.py
@@ -8,8 +8,8 @@ from cashflow.core.validate import validate
 @settings(max_examples=10, deadline=None)
 @given(
     delta=st.integers(
-        min_value=-1000, max_value=1000
-    ),  # cents delta around canonical target
+        min_value=-500, max_value=1000
+    ),  # cents delta around canonical target (Spark schedule cannot drop further)
     band_extra=st.integers(min_value=0, max_value=2000),  # widen band modestly
 )
 def test_randomized_target_and_band_keeps_validity(delta, band_extra):

--- a/cashflow/tests/regression/test_regression_objective.py
+++ b/cashflow/tests/regression/test_regression_objective.py
@@ -13,5 +13,5 @@ def test_regression_objective_and_final():
     assert s1.final_closing_cents == s2.final_closing_cents
 
     # Lock current baseline (update if solver logic changes intentionally)
-    assert s1.objective == (19, 11, 97, 3, 6)
-    assert s1.final_closing_cents == 48953
+    assert s1.objective == (22, 17, 1953)
+    assert s1.final_closing_cents == 51003

--- a/cashflow/tests/unit/test_large_adjustments.py
+++ b/cashflow/tests/unit/test_large_adjustments.py
@@ -10,19 +10,10 @@ from cashflow.core.validate import validate
 def _tail_extra_capacity(actions, start_day_exclusive):
     # Optimistic capacity (ignores Off-Off). Not used for final negative bound.
     cap = 0
+    max_net = max(SHIFT_NET_CENTS.values())
     for t in range(start_day_exclusive + 1, 31):
         base_net = SHIFT_NET_CENTS[actions[t - 1]]
-        cap += 12000 - base_net
-    return cap
-
-
-def _tail_upgrade_capacity_no_new_workdays(actions, start_day_exclusive):
-    # Safe capacity by upgrading within worked days only: S->SS and L->SS
-    cap = 0
-    for t in range(start_day_exclusive + 1, 31):
-        a = actions[t - 1]
-        if a in ("S", "L"):
-            cap += 12000 - SHIFT_NET_CENTS[a]
+        cap += max_net - base_net
     return cap
 
 
@@ -33,9 +24,9 @@ def test_large_positive_adjustments_multiple_days():
 
     cases = {
         4: 10000,  # +$100
-        10: 25000,  # +$250
-        17: 50000,  # +$500
-        24: 30000,  # +$300
+        10: 20000,  # +$200
+        17: 30000,  # +$300
+        24: 20000,  # +$200
     }
 
     for day, delta in cases.items():
@@ -61,16 +52,12 @@ def test_large_negative_adjustments_safe_with_capacity():
     base_sched = solve(plan)
     base_ledg = build_ledger(plan, base_sched.actions)
 
-    for day in [10, 20]:
-        # use only upgrade capacity that doesn't add workdays (keeps Off-Off intact)
-        up_cap = _tail_upgrade_capacity_no_new_workdays(base_sched.actions, day)
-        if up_cap < 5000:  # need at least ~$50 upgrade room
+    negative_cases = {10: -3000, 20: -3000}
+
+    for day, delta in negative_cases.items():
+        up_cap = _tail_extra_capacity(base_sched.actions, day)
+        if up_cap < abs(delta):
             pytest.skip(f"insufficient upgrade capacity after day {day}")
-        # bound by closing and upgrade capacity minus a margin
-        max_safe = min(base_ledg[day - 1].closing_cents - 100, up_cap - 500)
-        if max_safe <= 0:
-            pytest.skip(f"no safe negative margin on day {day}")
-        delta = -max_safe
 
         plan2 = load_plan("plan.json")
         plan2.actions = base_sched.actions[:day] + [None] * (30 - day)
@@ -95,7 +82,7 @@ def test_day30_large_positive_adjustment_with_flexible_action():
     base_ledg = build_ledger(plan, base_sched.actions)
 
     day = 30
-    delta = 25000  # +$250
+    delta = 10000  # +$100
 
     plan2 = load_plan("plan.json")
     # lock only up to day 27; allow days 28-30 to adjust to absorb +$250
@@ -111,5 +98,5 @@ def test_day30_large_positive_adjustment_with_flexible_action():
     for t in range(1, 28):
         assert ledg2[t - 1].closing_cents == base_ledg[t - 1].closing_cents
         assert sched2.actions[t - 1] == base_sched.actions[t - 1]
-    # Day 30 closing should be within band via action adjustment
-    assert ledg2[29].closing_cents != base_ledg[29].closing_cents  # likely changed
+    # Some of the flexible tail actions should adjust to absorb the delta
+    assert sched2.actions[27:] != base_sched.actions[27:]

--- a/cashflow/tests/unit/test_validate_rules.py
+++ b/cashflow/tests/unit/test_validate_rules.py
@@ -18,8 +18,8 @@ def test_validation_rules_hold():
     # Global ok
     assert report.ok, report.checks
 
-    # Day 1 must be Large
-    assert schedule.actions[0] == "L"
+    # Day 1 must be Spark
+    assert schedule.actions[0] == "Spark"
 
     # Off-Off windows across [1..7] and [24..30]
     actions = schedule.actions


### PR DESCRIPTION
## Summary
- replace the Flex shift tiers with a single $100 Spark workday across the DP solver, validation, and CLI rendering
- update the CP-SAT verifier plus unit/property/regression tests for the new three-part objective and Spark-specific adjustments
- refresh README and instructions to document Spark payouts, constraints, and updated validation rules

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84cd2a574832599351e1c1f571827