### PR TITLE
feat: adopt spark workday shift model

### DIFF
--- a/cashflow/cli.py
+++ b/cashflow/cli.py
@@ -112,7 +112,7 @@ def cmd_verify(
     typer.echo("DP Objective:   " + str(schedule.objective))
     typer.echo("CP-SAT Objective: " + str(report.cp_obj))
     if getattr(report, "statuses", None):
-        names = ["workdays", "b2b", "|Δ|", "large_days", "single_pen"]
+        names = ["workdays", "b2b", "|Δ|"]
         typer.echo("Solver statuses:")
         for i, s in enumerate(report.statuses or []):
             label = names[i] if i < len(names) else f"part{i+1}"

--- a/cashflow/core/model.py
+++ b/cashflow/core/model.py
@@ -17,13 +17,10 @@ def cents_to_str(cents: int) -> str:
     return f"{sign}{cents_abs // 100}.{cents_abs % 100:02d}"
 
 
-# Shift net values (already subtracting $8 work cost when worked)
+# Shift net values for Spark (integer cents, no per-shift deductions)
 SHIFT_NET_CENTS: Dict[str, int] = {
     "O": 0,
-    "S": 5600,
-    "M": 6750,
-    "L": 8650,
-    "SS": 12000,
+    "W": 10_000,
 }
 
 
@@ -74,8 +71,8 @@ class DayLedger:
 
 @dataclass
 class Schedule:
-    actions: List[str]  # 30 entries from {O,S,M,L,SS}
-    objective: Tuple[int, int, int, int, int]
+    actions: List[str]  # 30 entries from {O,W}
+    objective: Tuple[int, int, int]
     final_closing_cents: int
     ledger: List[DayLedger]
 

--- a/cashflow/core/validate.py
+++ b/cashflow/core/validate.py
@@ -29,9 +29,9 @@ def validate(plan: Plan, schedule: Schedule) -> ValidationReport:
     dep, bills, base = build_prefix_arrays(plan)
     checks: List[Tuple[str, bool, str]] = []
 
-    # Day 1 must be L
-    day1_ok = schedule.actions[0] == "L"
-    checks.append(("Day 1 Large", day1_ok, schedule.actions[0]))
+    # Day 1 must be a Spark workday
+    day1_ok = schedule.actions[0] == "W"
+    checks.append(("Day 1 Spark", day1_ok, schedule.actions[0]))
 
     # Non-negativity & bills paid by construction
     nonneg_ok = True

--- a/cashflow/engines/cpsat.py
+++ b/cashflow/engines/cpsat.py
@@ -6,20 +6,20 @@ captures the same feasibility rules and objective used by the DP solver. It is
 used to:
 
 - Solve a sequential lexicographic objective (workdays, back-to-back work,
-  |final diff|, number of large days, and a final single-day penalty) and
-  extract an optimal 30-day schedule.
+  and |final diff|) and extract an optimal 30-day schedule.
 - Cross-check a DP-produced schedule for lexicographic optimality.
 - Enumerate alternative schedules ("ties") that achieve the exact same
   lexicographic objective value.
 
 Key ideas:
-- One-hot action variable per day over ACTIONS = ("O","S","M","L","SS").
+- One-hot action variable per day over ACTIONS = ("O","W").
 - Derived boolean indicators for off/work, back-to-back work pairs, and
   off-off pairs in adjacent days.
 - Integer prefix balance recursion over net cents deltas per action.
 - Feasibility constraints mirror validator rules: non-negative daily closings,
-  Day-1 Large, Day-30 pre-rent guard, final band, and an Off-Off window rule.
-- Sequential lexicographic optimization modeled by solving 5 stages in order
+  Day-1 Spark workday, Day-30 pre-rent guard, final band, and an Off-Off window
+  rule.
+- Sequential lexicographic optimization modeled by solving 3 stages in order
   and fixing the previous objective part to its optimum before proceeding.
 """
 
@@ -46,7 +46,7 @@ from ..core.model import (
 # Notes on core.model imports:
 # - Plan: input data class describing the month, target band, rent guard, and
 #   optional per-day action locks. Only a subset of fields is used here.
-# - SHIFT_NET_CENTS: mapping from action symbol (e.g., "M") to integer cents
+# - SHIFT_NET_CENTS: mapping from action symbol (e.g., "W") to integer cents
 #   representing the net cash delta contributed by performing that action on a
 #   given day.
 # - build_prefix_arrays(plan): returns deterministic base arrays (deposit/bill
@@ -57,11 +57,12 @@ from ..core.model import (
 #   applying action deltas on or before Day-30).
 
 
-ActionList = ["O", "S", "M", "L", "SS"]
+ActionList = ["O", "W"]
 # Canonical action order used to index decision variables. This order must
 # match how SHIFT_NET_CENTS is accessed below.
-ACTIONS = ("O", "S", "M", "L", "SS")
+ACTIONS = ("O", "W")
 IDX: Dict[str, int] = {a: i for i, a in enumerate(ACTIONS)}
+NUM_ACTIONS = len(ACTIONS)
 
 
 @dataclass
@@ -75,7 +76,7 @@ class CPSATSolution:
     """
 
     actions: List[str]
-    objective: Tuple[int, int, int, int, int]
+    objective: Tuple[int, int, int]
     final_closing_cents: int
     statuses: List[str]
 
@@ -90,8 +91,8 @@ class VerificationReport:
     """
 
     ok: bool
-    dp_obj: Tuple[int, int, int, int, int]
-    cp_obj: Tuple[int, int, int, int, int]
+    dp_obj: Tuple[int, int, int]
+    cp_obj: Tuple[int, int, int]
     dp_actions: List[str]
     cp_actions: List[str]
     detail: str = ""
@@ -126,7 +127,7 @@ def _build_model(plan: Plan):
 
     # Decision vars
     # x[t][a] == 1 iff action `ACTIONS[a]` is chosen on day t.
-    x = [[model.NewBoolVar(f"x_{t}_{a}") for a in range(5)] for t in range(30)]
+    x = [[model.NewBoolVar(f"x_{t}_{a}") for a in range(NUM_ACTIONS)] for t in range(30)]
     off = [model.NewBoolVar(f"off_{t}") for t in range(30)]
     w = [model.NewBoolVar(f"w_{t}") for t in range(30)]
     # Adjacent-pair indicators for (work,work) and (off,off).
@@ -134,7 +135,8 @@ def _build_model(plan: Plan):
     oo = [model.NewBoolVar(f"oo_{t}") for t in range(29)]
     # Cumulative sum of action deltas (in cents) up to day t.
     # Upper bound is a safe coarse cap to keep domains finite.
-    prefix_net = [model.NewIntVar(0, 12000 * (t + 1), f"pref_{t}") for t in range(30)]
+    max_net = max(SHIFT_NET_CENTS.values())
+    prefix_net = [model.NewIntVar(0, max_net * (t + 1), f"pref_{t}") for t in range(30)]
     final_close = model.NewIntVar(-(10**9), 10**9, "final_close")
     abs_diff = model.NewIntVar(0, 10**9, "abs_diff")
 
@@ -154,13 +156,13 @@ def _build_model(plan: Plan):
         # This is how users can "pin" certain days when exploring schedules.
         locked = plan.actions[t]
         if locked is not None:
-            for a in range(5):
+            for a in range(NUM_ACTIONS):
                 model.Add(x[t][a] == (1 if a == IDX[locked] else 0))
 
-    # Day 1 Large
-    # Business rule: the first day must be a Large shift. This mirrors the
+    # Day 1 Spark workday
+    # Business rule: the first day must be a Spark shift. This mirrors the
     # validator and DP solver’s model assumptions.
-    model.Add(x[0][IDX["L"]] == 1)
+    model.Add(x[0][IDX["W"]] == 1)
 
     # off, w
     for t in range(30):
@@ -187,12 +189,13 @@ def _build_model(plan: Plan):
     # Map actions to per-day net cents deltas.
     net_vec = [SHIFT_NET_CENTS[a] for a in ACTIONS]
     # day 0
-    model.Add(prefix_net[0] == sum(net_vec[a] * x[0][a] for a in range(5)))
+    model.Add(prefix_net[0] == sum(net_vec[a] * x[0][a] for a in range(NUM_ACTIONS)))
     for t in range(1, 30):
         # prefix_net[t] = prefix_net[t-1] + net(action_t)
         model.Add(
             prefix_net[t]
-            == prefix_net[t - 1] + sum(net_vec[a] * x[t][a] for a in range(5))
+            == prefix_net[t - 1]
+            + sum(net_vec[a] * x[t][a] for a in range(NUM_ACTIONS))
         )
     # With base[] provided by build_prefix_arrays, the closing balance on day t
     # is base[t+1] + prefix_net[t]. The constraints below enforce feasibility.
@@ -220,24 +223,18 @@ def _build_model(plan: Plan):
         model.Add(sum(oo[i] for i in range(s, s + 6)) >= 1)
 
     # Objective components
-    # We optimize lexicographically over these five parts (in order):
+    # We optimize lexicographically over these three parts (in order):
     # 1) Minimize total workdays; 2) minimize back-to-back work pairs;
-    # 3) minimize |final diff from target|; 4) minimize number of Large days;
-    # 5) minimize a tie-breaker penalizing M and especially L.
+    # 3) minimize |final diff from target|.
     workdays = sum(w)
     b2b_sum = sum(b2b)
-    large_days = sum(x[t][IDX["L"]] for t in range(30))
-    single_pen = sum(x[t][IDX["M"]] + 2 * x[t][IDX["L"]] for t in range(30))
     # Notes:
     # - workdays: encourages more off days when feasible.
     # - b2b_sum: discourages consecutive working days to spread work out.
     # - abs_diff: centers final balance within the target band with a preference
     #   toward the target itself when multiple values lie within the band.
-    # - large_days: prefers fewer Large shifts after satisfying (1)-(3).
-    # - single_pen: final tie-breaker to prefer Medium over Large, and avoid
-    #   unnecessary Mediums as well.
 
-    return model, x, (workdays, b2b_sum, abs_diff, large_days, single_pen), final_close
+    return model, x, (workdays, b2b_sum, abs_diff), final_close
 
 
 def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
@@ -258,16 +255,14 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
     # First, get the optimal objective via sequential lex optimization
     model_opt, x_opt, obj_parts, final_close_opt = _build_model(plan)
     solver_opt = cp_model.CpSolver()
-    w, b2b, absd, large, sp = _solve_sequential_lex(model_opt, obj_parts, solver_opt)
+    w, b2b, absd = _solve_sequential_lex(model_opt, obj_parts, solver_opt)
 
     # Build a fresh model with the same constraints and fix the objective parts to the optimal values
     model, x, obj_parts2, final_close = _build_model(plan)
-    workdays, b2b_sum, abs_diff, large_days, single_pen = obj_parts2
+    workdays, b2b_sum, abs_diff = obj_parts2
     model.Add(workdays == w)
     model.Add(b2b_sum == b2b)
     model.Add(abs_diff == absd)
-    model.Add(large_days == large)
-    model.Add(single_pen == sp)
 
     # Enumerate feasible solutions (no objective)
     sols: List[CPSATSolution] = []
@@ -284,7 +279,7 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
             actions: List[str] = []
             for t in range(30):
                 idx = None
-                for a in range(5):
+                for a in range(NUM_ACTIONS):
                     if self.Value(x[t][a]) == 1:
                         idx = a
                         break
@@ -298,7 +293,7 @@ def enumerate_ties(plan: Plan, limit: int = 5) -> List[CPSATSolution]:
             sols.append(
                 CPSATSolution(
                     actions=actions,
-                    objective=(w, b2b, absd, large, sp),
+                    objective=(w, b2b, absd),
                     final_closing_cents=final_cents,
                 )
             )
@@ -335,14 +330,14 @@ def _status_name(code: object) -> str:
 
 
 def _solve_sequential_lex(model, obj_parts, solver: "cp_model.CpSolver"):
-    """Solve a 5-part lexicographic objective sequentially.
+    """Solve a 3-part lexicographic objective sequentially.
 
     At each stage, minimize the current part, record the optimum, then add an
     equality constraint fixing that part before moving to the next. This is a
     standard technique to emulate lexicographic optimization with CP-SAT.
     Returns the optimal values for each part along with per-stage statuses.
     """
-    workdays, b2b_sum, abs_diff, large_days, single_pen = obj_parts
+    workdays, b2b_sum, abs_diff = obj_parts
 
     statuses: List[str] = []
 
@@ -375,23 +370,7 @@ def _solve_sequential_lex(model, obj_parts, solver: "cp_model.CpSolver"):
     best_abs = solver.Value(abs_diff)
     model.Add(abs_diff == best_abs)
 
-    # 4) Minimize large_days
-    model.Minimize(large_days)
-    r = solver.Solve(model)
-    statuses.append(_status_name(r))
-    if r not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        raise RuntimeError("CP-SAT failed for objective 4")
-    best_large = solver.Value(large_days)
-    model.Add(large_days == best_large)
-
-    # 5) Minimize single_pen (final tie-breaker among Large/Medium usage)
-    model.Minimize(single_pen)
-    r = solver.Solve(model)
-    statuses.append(_status_name(r))
-    if r not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        raise RuntimeError("CP-SAT failed for objective 5")
-
-    return best_work, best_b2b, best_abs, best_large, solver.Value(single_pen), statuses
+    return best_work, best_b2b, best_abs, statuses
 
 
 def solve_lex(plan: Plan) -> CPSATSolution:
@@ -401,13 +380,13 @@ def solve_lex(plan: Plan) -> CPSATSolution:
 
     model, x, obj_parts, final_close = _build_model(plan)
     solver = cp_model.CpSolver()
-    w, b2b, absd, large, sp, statuses = _solve_sequential_lex(model, obj_parts, solver)
+    w, b2b, absd, statuses = _solve_sequential_lex(model, obj_parts, solver)
 
     # Extract actions from the solved one-hot variables.
     actions: List[str] = []
     for t in range(30):
         idx = None
-        for a in range(5):
+        for a in range(NUM_ACTIONS):
             if solver.Value(x[t][a]) == 1:
                 idx = a
                 break
@@ -419,7 +398,7 @@ def solve_lex(plan: Plan) -> CPSATSolution:
     final_cents = solver.Value(final_close)
     sol = CPSATSolution(
         actions=actions,
-        objective=(w, b2b, absd, large, sp),
+        objective=(w, b2b, absd),
         final_closing_cents=final_cents,
         statuses=statuses,
     )
@@ -438,7 +417,7 @@ def verify_lex_optimal(plan: Plan, schedule_dp) -> VerificationReport:
         return VerificationReport(
             ok=False,
             dp_obj=schedule_dp.objective,
-            cp_obj=(-1, -1, -1, -1, -1),
+            cp_obj=(-1, -1, -1),
             dp_actions=schedule_dp.actions,
             cp_actions=[],
             detail=f"CP-SAT error: {e}",

--- a/cashflow/engines/dp.py
+++ b/cashflow/engines/dp.py
@@ -14,15 +14,13 @@ from ..core.model import (
 from ..core.ledger import build_ledger
 
 
-Action = str  # 'O','S','M','L','SS'
+Action = str  # 'O','W'
 
 
 @dataclass
 class _StateVal:
     # costs that are additive across days
     b2b: int
-    large_days: int
-    single_pen: int
     back: Optional[Tuple]  # (prev_state_key, action)
 
 
@@ -32,10 +30,10 @@ def _allowed_actions(
     if locked is not None:
         return [locked]
     if day == 1:
-        return ["L"]
-    if forbid_large_after_day1:
-        return ["O", "S", "M", "SS"]
-    return ["O", "S", "M", "SS", "L"]
+        return ["W"]
+    # `forbid_large_after_day1` is retained for compatibility but has no
+    # effect in the Spark model (there is only one work action).
+    return ["O", "W"]
 
 
 def _has_off_off(vec: List[int]) -> bool:
@@ -53,7 +51,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
     min_net = (plan.target_end_cents - plan.band_cents) - base_end
     max_net = (plan.target_end_cents + plan.band_cents) - base_end
     # Max per remaining day
-    MAX_DAY_NET = 12000
+    MAX_DAY_NET = max(SHIFT_NET_CENTS.values())
 
     pre30 = pre_rent_base_on_day30(plan, dep, bills)
 
@@ -61,9 +59,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
     # State key: (last6_off_tuple, prevWorked:int, workUsed:int, net:int)
     # last6_off_tuple: tuple[int,...] oldest->newest, len<=6
     layers: List[Dict[Tuple, _StateVal]] = []
-    s0: Dict[Tuple, _StateVal] = {
-        ((), 0, 0, 0): _StateVal(b2b=0, large_days=0, single_pen=0, back=None)
-    }
+    s0: Dict[Tuple, _StateVal] = {((), 0, 0, 0): _StateVal(b2b=0, back=None)}
     layers.append(s0)
 
     for day in range(1, 31):
@@ -108,36 +104,28 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
 
                 # Update costs
                 b2b_new = val.b2b + (1 if (prevW == 1 and will_work == 1) else 0)
-                large_days_new = val.large_days + (1 if a == "L" else 0)
-                single_pen_new = val.single_pen + (
-                    1 if a == "M" else 2 if a == "L" else 0
-                )
 
                 state_key = (last6_new, 1 if will_work else 0, work_used_new, net_new)
                 new_val = _StateVal(
                     b2b=b2b_new,
-                    large_days=large_days_new,
-                    single_pen=single_pen_new,
                     back=((last6_off_tuple, prevW, workUsed, net), a),
                 )
 
-                # Keep lexicographically best by (work_used, b2b, large_days, single_pen)
+                # Keep lexicographically best by (work_used, b2b)
                 existing = cur.get(state_key)
                 if existing is None:
                     cur[state_key] = new_val
                 else:
-                    if (work_used_new, b2b_new, large_days_new, single_pen_new) < (
+                    if (work_used_new, b2b_new) < (
                         work_used_new,
                         existing.b2b,
-                        existing.large_days,
-                        existing.single_pen,
                     ):
                         cur[state_key] = new_val
 
         layers.append(cur)
 
     # Select best final state within band
-    best_tuple: Optional[Tuple[Tuple[int, int, int, int, int], Tuple, _StateVal]] = None
+    best_tuple: Optional[Tuple[Tuple[int, int, int], Tuple, _StateVal]] = None
     for (last6_off, prevW, workUsed, net), val in layers[-1].items():
         final_closing = base[30] + net
         if not (
@@ -147,7 +135,7 @@ def solve(plan: Plan, *, forbid_large_after_day1: bool = False) -> Schedule:
         ):
             continue
         abs_delta = abs(final_closing - plan.target_end_cents)
-        obj = (workUsed, val.b2b, abs_delta, val.large_days, val.single_pen)
+        obj = (workUsed, val.b2b, abs_delta)
         if best_tuple is None or obj < best_tuple[0]:
             best_tuple = (obj, (last6_off, prevW, workUsed, net), val)
 

--- a/cashflow/io/calendar.py
+++ b/cashflow/io/calendar.py
@@ -61,7 +61,6 @@ def render_calendar_png(
     sub = (168, 176, 190) if theme == "dark" else (90, 96, 108)
     off_fill = (58, 62, 72) if theme == "dark" else (220, 224, 232)
     work_fill = (36, 140, 86) if theme == "dark" else (52, 168, 98)
-    large_fill = (184, 104, 44) if theme == "dark" else (214, 144, 84)
 
     grid_gap = int(24 * scale)
     margin = int(80 * scale)
@@ -104,9 +103,9 @@ def render_calendar_png(
             (cx - wt / 2, header_y - ht / 2), month_title, fill=fg, font=title_font
         )
 
-    w, b2b, delta, large, sp = schedule.objective
+    w, b2b, delta = schedule.objective
     obj_line = (
-        f"work={w}  b2b={b2b}  |Δ|={cents_to_str(delta)}  L={large}  pen={sp}  "
+        f"work={w}  b2b={b2b}  |Δ|={cents_to_str(delta)}  "
         f"final={cents_to_str(schedule.final_closing_cents)}"
     )
     wo, ho = text_size(obj_line, obj_font)
@@ -170,11 +169,7 @@ def render_calendar_png(
 
         row = schedule.ledger[d - 1] if d - 1 < len(schedule.ledger) else None
         if row:
-            fill = (
-                large_fill
-                if row.action == "L"
-                else (work_fill if row.action != "O" else off_fill)
-            )
+            fill = work_fill if row.action != "O" else off_fill
             text_col = fg
         else:
             fill, text_col = off_fill, sub

--- a/cashflow/io/render.py
+++ b/cashflow/io/render.py
@@ -8,8 +8,8 @@ from ..core.model import Schedule, cents_to_str
 def render_markdown(schedule: Schedule) -> str:
     lines: List[str] = []
     # Display shift payout as its own column and list it after the action
-    # to reflect that Flex deposits occur after working (SS deposits after
-    # the second shift). External deposits remain in the Deposits column.
+    # to reflect that Spark payouts are captured when the workday completes.
+    # External deposits remain in the Deposits column.
     lines.append("| Day | Opening | Action | Payout | Deposits | Bills | Closing |")
     lines.append("| ---:| -------:|:------:| ------:| --------:| -----:| -------:|")
     for row in schedule.ledger:
@@ -17,9 +17,9 @@ def render_markdown(schedule: Schedule) -> str:
             f"| {row.day:>3} | {cents_to_str(row.opening_cents):>7} | {row.action:^6} | {cents_to_str(row.net_cents):>6} | {cents_to_str(row.deposit_cents):>8} | {cents_to_str(row.bills_cents):>5} | {cents_to_str(row.closing_cents):>7} |"
         )
     lines.append("")
-    w, b2b, delta, large, sp = schedule.objective
+    w, b2b, delta = schedule.objective
     lines.append(
-        f"Objective: workdays={w}, b2b={b2b}, |Δ|={cents_to_str(delta)}, large_days={large}, single_pen={sp}"
+        f"Objective: workdays={w}, b2b={b2b}, |Δ|={cents_to_str(delta)}"
     )
     lines.append(f"Final closing: {cents_to_str(schedule.final_closing_cents)}")
     return "\n".join(lines)

--- a/cashflow/tests/regression/test_regression_objective.py
+++ b/cashflow/tests/regression/test_regression_objective.py
@@ -13,5 +13,5 @@ def test_regression_objective_and_final():
     assert s1.final_closing_cents == s2.final_closing_cents
 
     # Lock current baseline (update if solver logic changes intentionally)
-    assert s1.objective == (19, 11, 97, 3, 6)
-    assert s1.final_closing_cents == 48953
+    assert s1.objective == (22, 17, 1953)
+    assert s1.final_closing_cents == 51003

--- a/cashflow/tests/unit/test_large_adjustments.py
+++ b/cashflow/tests/unit/test_large_adjustments.py
@@ -1,29 +1,8 @@
-import pytest
-
 from cashflow.io.store import load_plan
 from cashflow.engines.dp import solve
 from cashflow.core.ledger import build_ledger
-from cashflow.core.model import Adjustment, SHIFT_NET_CENTS
+from cashflow.core.model import Adjustment
 from cashflow.core.validate import validate
-
-
-def _tail_extra_capacity(actions, start_day_exclusive):
-    # Optimistic capacity (ignores Off-Off). Not used for final negative bound.
-    cap = 0
-    for t in range(start_day_exclusive + 1, 31):
-        base_net = SHIFT_NET_CENTS[actions[t - 1]]
-        cap += 12000 - base_net
-    return cap
-
-
-def _tail_upgrade_capacity_no_new_workdays(actions, start_day_exclusive):
-    # Safe capacity by upgrading within worked days only: S->SS and L->SS
-    cap = 0
-    for t in range(start_day_exclusive + 1, 31):
-        a = actions[t - 1]
-        if a in ("S", "L"):
-            cap += 12000 - SHIFT_NET_CENTS[a]
-    return cap
 
 
 def test_large_positive_adjustments_multiple_days():
@@ -33,7 +12,7 @@ def test_large_positive_adjustments_multiple_days():
 
     cases = {
         4: 10000,  # +$100
-        10: 25000,  # +$250
+        10: 20000,  # +$200 (Spark increments are $100)
         17: 50000,  # +$500
         24: 30000,  # +$300
     }
@@ -61,17 +40,8 @@ def test_large_negative_adjustments_safe_with_capacity():
     base_sched = solve(plan)
     base_ledg = build_ledger(plan, base_sched.actions)
 
-    for day in [10, 20]:
-        # use only upgrade capacity that doesn't add workdays (keeps Off-Off intact)
-        up_cap = _tail_upgrade_capacity_no_new_workdays(base_sched.actions, day)
-        if up_cap < 5000:  # need at least ~$50 upgrade room
-            pytest.skip(f"insufficient upgrade capacity after day {day}")
-        # bound by closing and upgrade capacity minus a margin
-        max_safe = min(base_ledg[day - 1].closing_cents - 100, up_cap - 500)
-        if max_safe <= 0:
-            pytest.skip(f"no safe negative margin on day {day}")
-        delta = -max_safe
-
+    cases = {10: -4000, 20: -4000}
+    for day, delta in cases.items():
         plan2 = load_plan("plan.json")
         plan2.actions = base_sched.actions[:day] + [None] * (30 - day)
         plan2.manual_adjustments = plan2.manual_adjustments + [
@@ -95,10 +65,10 @@ def test_day30_large_positive_adjustment_with_flexible_action():
     base_ledg = build_ledger(plan, base_sched.actions)
 
     day = 30
-    delta = 25000  # +$250
+    delta = 20000  # +$200
 
     plan2 = load_plan("plan.json")
-    # lock only up to day 27; allow days 28-30 to adjust to absorb +$250
+    # lock only up to day 27; allow days 28-30 to adjust to absorb +$200
     plan2.actions = base_sched.actions[:27] + [None, None, None]
     plan2.manual_adjustments = plan2.manual_adjustments + [
         Adjustment(day=day, amount_cents=delta, note="d30 large+")
@@ -111,5 +81,5 @@ def test_day30_large_positive_adjustment_with_flexible_action():
     for t in range(1, 28):
         assert ledg2[t - 1].closing_cents == base_ledg[t - 1].closing_cents
         assert sched2.actions[t - 1] == base_sched.actions[t - 1]
-    # Day 30 closing should be within band via action adjustment
-    assert ledg2[29].closing_cents != base_ledg[29].closing_cents  # likely changed
+    # Day 30 deposit reflects the manual adjustment (even if closing stays the same)
+    assert ledg2[29].deposit_cents == base_ledg[29].deposit_cents + delta

--- a/cashflow/tests/unit/test_validate_rules.py
+++ b/cashflow/tests/unit/test_validate_rules.py
@@ -18,8 +18,8 @@ def test_validation_rules_hold():
     # Global ok
     assert report.ok, report.checks
 
-    # Day 1 must be Large
-    assert schedule.actions[0] == "L"
+    # Day 1 must be Spark workday
+    assert schedule.actions[0] == "W"
 
     # Off-Off windows across [1..7] and [24..30]
     actions = schedule.actions

--- a/instructions.md
+++ b/instructions.md
@@ -38,7 +38,7 @@ Plan daily work shifts and pay bills across a fixed 30‑day horizon with exact 
 ## 1.5 Non‑Goals
 
 - No cloud services, no persistent user auth, no graphics beyond terminal/TUI.
-- No real‑time Amazon Flex integration.
+- No real‑time Spark integration.
 
 ---
 
@@ -46,11 +46,10 @@ Plan daily work shifts and pay bills across a fixed 30‑day horizon with exact 
 
 ## 2.1 Functional Requirements
 
-- FR‑01: Solve full month (days 1–30) with **intra‑day order**: opening → deposits → shifts (gross − \$8 if any shift) → bills → closing.
+- FR‑01: Solve full month (days 1–30) with **intra‑day order**: opening → deposits → shifts (+\$100 if Spark worked) → bills → closing.
 - FR‑02: Enforce **hard constraints** (see §7 Validation Rules).
 - FR‑03: Lexicographic objective:
-  `( #work_days, back_to_back_count, |final − 490.50|, large_day_count, single_shift_preference )`
-  where single‑shift preference penalizes M=1, L=2 (S=0, SS=0).
+  `( #work_days, back_to_back_count, |final − 490.50| )`
 - FR‑04: Resume from day _d+1_: after inserting a manual adjustment on day _d_, seed DP with prefix state and re‑solve tail.
 - FR‑05: Output Sections 1–3 exactly in markdown; optional JSON/CSV.
 - FR‑06: CLI commands (see §6).
@@ -98,7 +97,7 @@ cashflow/
 
 1. Load `plan.json` → event stream.
 2. Build ledger day‑by‑day (deposits/bills/adjustments).
-3. Run DP solver → `actions[1..30]` (each ∈ {O,S,M,L,SS}).
+3. Run DP solver → `actions[1..30]` (each ∈ {O,W}).
 4. Produce Section 1–3 views; run validator; export.
 
 ## 3.3 Data Flow (Resume from Day _d+1_)
@@ -127,7 +126,7 @@ State value stores **cost tuple**: `(b2b, large_count, single_pen)` plus backpoi
 
 - `deposit`: {day, amount}
 - `bill`: {day, name, amount}
-- `shift`: {day, code in \[O,S,M,L,SS]}
+- `shift`: {day, code in \[O,W]}
 - `adjustment`: {day, amount, note} ← created by EOD override
 - `meta`: target_end, band, rent_guard
 
@@ -197,7 +196,7 @@ State value stores **cost tuple**: `(b2b, large_count, single_pen)` plus backpoi
       "maxItems": 30,
       "items": {
         "type": ["string", "null"],
-        "enum": ["O", "S", "M", "L", "SS", null]
+        "enum": ["O", "W", null]
       }
     },
     "manual_adjustments": {
@@ -233,34 +232,31 @@ State value stores **cost tuple**: `(b2b, large_count, single_pen)` plus backpoi
 
 ## 5.1 DP (Primary)
 
-- **Actions per day:** `A = {'O','S','M','L','SS'}` (Day 1: `{'L'}`).
-- **Net per action (cents):** `O=0, S=5600, M=6750, L=8650, SS=12000`.
+- **Actions per day:** `A = {'O','W'}` (Day 1: `{'W'}`).
+- **Net per action (cents):** `O=0, W=10000`.
 - **Transition feasibility (per day `t`):**
 
   1. **7‑day Off‑Off Rule:** In any rolling 7‑day window ending at `t`, there must exist at least one `Off,Off` pair. Enforced by checking the current 7‑vector derived from `(bits,cnt)` plus today’s Off flag.
   2. **Non‑negativity:** `closing_t >= 0` after applying deposits, shift net, and bills for day `t`.
   3. **Rent guard (Day 30):** `pre_rent_balance >= rent_guard` after deposits & shifts (before paying rent).
-  4. **Shift pairing:** Two‑shift days allowed **only as SS**; Large cannot be in a two‑shift day; max two shifts per day.
-  5. **Day 1 Large:** Day 1 action must be `L`.
+  4. **Day 1 Spark:** Day 1 action must be `W`.
 
 - **Objective cost per step:**
 
   - `workdays += (action != 'O')`
   - `b2b += (prevWorked and action != 'O')`
-  - `large_days += (action == 'L')`
-  - `single_pen += 1 if action=='M' else 2 if action=='L' else 0` (SS, S, O give 0)
 
 - **Global selection:** After Day 30, select states with **final balance within target band** and minimum **lexicographic tuple**:
 
   ```
-  (workdays, b2b, abs(final - target_end), large_days, single_pen)
+  (workdays, b2b, abs(final - target_end))
   ```
 
 - **Lower/upper pruning:**
   Let `K` be the target workdays being searched (start from bound, increment only if needed).
   At day `t`, with `net_so_far` and `work_used`:
 
-  - Max additional net = `(K - work_used) * 12000`.
+  - Max additional net = `(K - work_used) * 10000`.
   - If `net_so_far + max_additional_net < MIN_NET`, prune.
   - If `net_so_far > MAX_NET`, prune.
 
@@ -276,7 +272,7 @@ for day in 1..30:
        if !rolling_off_off_ok(bits,cnt,a,day): continue
        net_new = net + NET[a]
        if net_new > MAX_NET: continue
-       if net_new + 12000*(K - (work+worked(a))) < MIN_NET: continue
+       if net_new + 10000*(K - (work+worked(a))) < MIN_NET: continue
        closing = opening(day) + deposits(day) + net_new - bills(day)
        if closing < 0: continue
        if day==30 and (opening30 + deposits30 + NET[a]) < RENT_GUARD: continue
@@ -287,17 +283,15 @@ for day in 1..30:
 
 ## 5.2 CP‑SAT (Cross‑Verification)
 
-- One‑hot daily vars: `x[t,action] ∈ {0,1}`.
+- One‑hot daily vars: `x[t,action] ∈ {0,1}` for `action ∈ {'O','W'}`.
 - Workday: `w[t] = 1 - x[t,'O']`.
 - B2B count: sum `b2b = Σ_t (w[t]*w[t+1])` (linearize with auxiliary vars).
 - Off‑Off in each 7‑day window: introduce `off[t] = x[t,'O']`; require `Σ_i z[i] ≥ 1` where `z[i] ≤ off[i]` and `z[i] ≤ off[i+1]` and `z[i] ≥ off[i]+off[i+1]-1`.
-- Day 1 `x[1,'L']=1`. Day 30 pre‑rent guard via linear balance constraints.
+- Day 1 `x[1,'W']=1`. Day 30 pre‑rent guard via linear balance constraints.
 - **Sequential lexicographic solving:**
   Solve 1: minimize `Σ w[t]`.
   Add equality; Solve 2: minimize `b2b`.
   Add equality; Solve 3: minimize `abs(final-target)` (linearized).
-  Add equality; Solve 4: minimize `Σ x[t,'L']`.
-  Add equality; Solve 5: minimize single‑shift penalty sum.
 
 ---
 
@@ -350,14 +344,12 @@ def validate(plan, schedule) -> ValidationReport: ...
 - **Balance non‑negative at all times** (after each day’s close).
 - **All bills paid on their due dates**.
 - **Final Day‑30 closing balance** ∈ `[490.50 ± 25.00]`.
-- **Day 1** must begin with **Large**.
-- **Max 2 shifts/day;** two‑shift days are **Small + Small** only.
-- **Large** scheduled alone (never paired); at most one Large per day.
-- **Work‑day cost**: if any shift worked that day, subtract exactly **\$8.00** once.
+- **Day 1** must begin with a **Spark workday** (`W`).
+- **Work‑day net**: each Spark shift contributes **\$100.00** (no deductions).
 - **Off day** = zero shifts, zero work cost.
 - **Every rolling 7‑day window** (windows \[1–7] … \[24–30]) contains at least **one “Off, Off” pair** (two consecutive Off days).
 - **Day‑30 rent guard:** after deposits and shifts on Day 30 (before rent), balance ≥ **\$1,636**.
-- **Intra‑day evaluation order**: Opening → Deposits → Shifts (gross−\$8 if worked) → Bills → Closing.
+- **Intra‑day evaluation order**: Opening → Deposits → Shifts (+$100 if worked) → Bills → Closing.
 
 ---
 
@@ -380,7 +372,7 @@ def validate(plan, schedule) -> ValidationReport: ...
 
 - Canonical dataset (the one you supplied) → assert:
 
-  - Objectives tuple equals `(19, 11, $0.97, 3, 0)` for the strict lexicographic optimum.
+  - Objectives tuple equals `(22, 17, $19.53)` for the strict lexicographic optimum.
   - Section 1–3 markdown matches golden (allowing whitespace tolerance).
 
 ## 8.4 Cross‑Verification
@@ -649,7 +641,7 @@ jobs:
 ## 16.4 Troubleshooting
 
 - **CP‑SAT not found:** install OR‑Tools or run `cash verify --engine dp-only`.
-- **“Infeasible” after EOD edit:** read the printed certificate; try increasing band or allowing an extra workday; consider removing `--forbid-large-after-day1`.
+- **“Infeasible” after EOD edit:** read the printed certificate; try increasing band or allowing an extra workday; the legacy `--forbid-large-after-day1` flag has no effect under Spark-only shifts.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the Amazon Flex tiered shifts with a single Spark workday worth $100 net and update the DP/CP-SAT objective to (workdays, b2b, |Δ|)
- refresh the CLI output, calendar/markdown renderers, and documentation to reflect the Spark model and new objective tuple
- realign regression/property/adjustment tests with the Spark $100 increments and new baseline schedule

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84cd2a574832599351e1c1f571827